### PR TITLE
Configurable hot-keys for spawning and removing

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
                             "explorer"
                         ],
                         "default": "explorer",
-                        "description": "VSCode pokemon webview position"
+                        "description": "VSCode pokemon webview position. 'panel' places it in a separate panel (like, 'explorer' places it in the explorer sidebar"
                     },
                     "vscode-pokemon.theme": {
                         "type": "string",
@@ -166,8 +166,58 @@
                         ],
                         "default": "none",
                         "description": "Background theme assets for your pokemon"
+                    },
+                    "vscode-pokemon.keybinding.spawnPokemon": {
+                        "type": "string",
+                        "default": "",
+                        "description": "Keyboard shortcut to spawn a specific pokemon (leave blank to disable, or set to a key combination like 'cmd+shift+s')"
+                    },
+                    "vscode-pokemon.keybinding.spawnRandomPokemon": {
+                        "type": "string",
+                        "default": "cmd+shift+l",
+                        "description": "Keyboard shortcut to spawn a random pokemon (leave blank to disable, or set to a key combination like 'cmd+shift+l')"
+                    },
+                    "vscode-pokemon.keybinding.deletePokemon": {
+                        "type": "string",
+                        "default": "",
+                        "description": "Keyboard shortcut to delete a specific pokemon (leave blank to disable, or set to a key combination like 'cmd+shift+d')"
+                    },
+                    "vscode-pokemon.keybinding.removeAllPokemon": {
+                        "type": "string",
+                        "default": "cmd+shift+k",
+                        "description": "Keyboard shortcut to remove all pokemon (leave blank to disable, or set to a key combination like 'cmd+shift+k')"
                     }
                 }
+            }
+        ],
+"keybindings": [
+            {
+                "command": "vscode-pokemon.spawn-pokemon",
+                "key": "",
+                "mac": "",
+                "win": "",
+                "linux": ""
+            },
+            {
+                "command": "vscode-pokemon.spawn-random-pokemon",
+                "key": "cmd+shift+l",
+                "mac": "cmd+shift+l",
+                "win": "ctrl+shift+l",
+                "linux": "ctrl+shift+l"
+            },
+            {
+                "command": "vscode-pokemon.delete-pokemon",
+                "key": "",
+                "mac": "",
+                "win": "",
+                "linux": ""
+            },
+            {
+                "command": "vscode-pokemon.remove-all-pokemon",
+                "key": "cmd+shift+k",
+                "mac": "cmd+shift+k",
+                "win": "ctrl+shift+k",
+                "linux": "ctrl+shift+k"
             }
         ]
     },


### PR DESCRIPTION
Added configurable hotkeys to the functions to spawn and remove Pokemon in the settings page.

Example use cases: 
Setting to panel view and pinning to the bottom and spamming spawning random

<img width="981" height="651" alt="Screenshot 2025-10-03 at 5 43 36 PM" src="https://github.com/user-attachments/assets/c1939845-cbe0-4e6a-bbbf-b5e6fdf0b26c" />

<img width="1364" height="1009" alt="Screenshot 2025-10-03 at 5 44 03 PM" src="https://github.com/user-attachments/assets/a5edccca-1b9f-4956-b5fd-ceb6695705b0" />
