### PR TITLE
feat: add default pokemon configurable through settings.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "vscode-pokemon" extension will be documented in this file.
 
+## [3.3.0]
+
+- feat: add default pokemon configurable through settings.json
+
 ## [3.2.2]
 
 - fix: issue when adding pokemon

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Set the size and position of the extension.
 
 ### Default Pokémon
 
-You can configure specific Pokémon to automatically appear when you start a coding session. This saves you from having to manually spawn your favorite Pokémon each time.
+You can configure specific Pokémon to automatically appear when you first start using the extension. This is useful for setting up your preferred team without having to manually spawn them when you switch sessions.
 
 To configure default Pokémon, add the following to your `settings.json`:
 
@@ -116,10 +116,8 @@ To configure default Pokémon, add the following to your `settings.json`:
 }
 ```
 
-- **`type`** (required): The Pokémon species (e.g., `"pikachu"`, `"charizard"`, `"bulbasaur"`)
+- **`type`** (required): The Pokémon species (e.g., `"pikachu"`, `"charizard"`, `"mewtwo"`)
 - **`name`** (optional): A custom name for your Pokémon. If not provided, a random name will be assigned
-
-If no default Pokémon are configured, the extension will load the Pokémon from your previous session.
 
 ## Upcoming features
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ To configure default Pokémon, add the following to your `settings.json`:
       "name": "Flame"
     },
     {
-      "type": "mewtwo"
+      "type": "articuno"
     }
   ]
 }
@@ -118,6 +118,12 @@ To configure default Pokémon, add the following to your `settings.json`:
 
 - **`type`** (required): The Pokémon species (e.g., `"pikachu"`, `"charizard"`, `"mewtwo"`)
 - **`name`** (optional): A custom name for your Pokémon. If not provided, a random name will be assigned
+
+**Note:** The extension automatically saves your current Pokémon between sessions. The `defaultPokemon` setting is only used when:
+- You start the extension for the first time
+- You have removed all Pokémon (no saved session exists)
+
+To reset to your default Pokémon, use the "Remove all pokemon" command and restart VS Code.
 
 ## Upcoming features
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Set the size and position of the extension.
 
 ### Default Pokémon
 
-You can configure specific Pokémon to automatically appear when you first start using the extension. This is useful for setting up your preferred team without having to manually spawn them when you switch between repositories.
+You can configure specific Pokémon to automatically appear when you first start using the extension. This is useful for setting up your preferred team without having to manually spawn them when you open new windows.
 
 To configure default Pokémon, add the following to your `settings.json`:
 
@@ -121,7 +121,7 @@ To configure default Pokémon, add the following to your `settings.json`:
 
 **Note:** The extension automatically saves your current Pokémon between sessions. The `defaultPokemon` setting is only used when:
 - You start the extension for the first time
-- You open a new repository
+- You open a new windows/repository
 - You have removed all Pokémon (no saved session exists)
 
 To reset to your default Pokémon, use the "Remove all pokemon" command and restart VS Code.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # VS Code Pokémon
 
 ![icon](https://github.com/jakobhoeg/vscode-pokemon/raw/main/icon.png)
-</div>    
+</div>
 
 <p align="center">
     Puts cute Pokémon in your code editor to boost productivity ✨
@@ -38,8 +38,8 @@ Seen used by engineers at [Microsoft](https://code.visualstudio.com/updates/v1_1
 
 ## 💖 Support
 
-If you enjoy this project, please consider supporting me.  
-Manually creating the `.gif` files for each sprite takes a lot of time and effort.  
+If you enjoy this project, please consider supporting me.
+Manually creating the `.gif` files for each sprite takes a lot of time and effort.
 Your sponsorship helps me dedicate more energy to improve and expand the project.
 
 [![GitHub Sponsor](https://img.shields.io/badge/Sponsor-❤-blue?style=flat&logo=github)](https://github.com/sponsors/jakobhoeg)
@@ -62,7 +62,7 @@ With VS Code open, launch VS Code Quick Open (`Ctrl+P` on Windows/Linux or `Cmd(
 
 ## Using VS Code Pokémon
 
-After installing, open the command palette with `Ctrl+Shift+P` on Windows/Linux or `Cmd(⌘)+Shift+P` on MacOS.  
+After installing, open the command palette with `Ctrl+Shift+P` on Windows/Linux or `Cmd(⌘)+Shift+P` on MacOS.
 
 Run the "Start Pokemon coding session" command (`vscode-pokemon.start`) to see a Bulbasaur in VS Code:
 
@@ -92,6 +92,35 @@ Open the setting panel with Ctrl+, on Windows/Linux or Cmd(⌘)+, on MacOS. In t
 
 Set the size and position of the extension.
 
+### Default Pokémon
+
+You can configure specific Pokémon to automatically appear when you start a coding session. This saves you from having to manually spawn your favorite Pokémon each time.
+
+To configure default Pokémon, add the following to your `settings.json`:
+
+```json
+{
+  "vscode-pokemon.defaultPokemon": [
+    {
+      "type": "pikachu",
+      "name": "Sparky"
+    },
+    {
+      "type": "charizard",
+      "name": "Flame"
+    },
+    {
+      "type": "mewtwo"
+    }
+  ]
+}
+```
+
+- **`type`** (required): The Pokémon species (e.g., `"pikachu"`, `"charizard"`, `"bulbasaur"`)
+- **`name`** (optional): A custom name for your Pokémon. If not provided, a random name will be assigned
+
+If no default Pokémon are configured, the extension will load the Pokémon from your previous session.
+
 ## Upcoming features
 
 Extracting and creating .gif files involves quite a bit of tedious manual work, but I’ll aim to add Gen 4 soon!
@@ -101,7 +130,7 @@ Extracting and creating .gif files involves quite a bit of tedious manual work, 
 ### Sprite Sources
 - Pokemon Sprites: © The Pokémon Company / Nintendo / Game Freak
 - The sprites are used for non-commercial, fan project purposes only
-- Original sprite artwork belongs to the respective copyright holders 
+- Original sprite artwork belongs to the respective copyright holders
 
 ### Acknowledgments
 - All sprites are property of their original creators

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Set the size and position of the extension.
 
 ### Default Pokémon
 
-You can configure specific Pokémon to automatically appear when you first start using the extension. This is useful for setting up your preferred team without having to manually spawn them when you switch sessions.
+You can configure specific Pokémon to automatically appear when you first start using the extension. This is useful for setting up your preferred team without having to manually spawn them when you switch between repositories.
 
 To configure default Pokémon, add the following to your `settings.json`:
 
@@ -121,6 +121,7 @@ To configure default Pokémon, add the following to your `settings.json`:
 
 **Note:** The extension automatically saves your current Pokémon between sessions. The `defaultPokemon` setting is only used when:
 - You start the extension for the first time
+- You open a new repository
 - You have removed all Pokémon (no saved session exists)
 
 To reset to your default Pokémon, use the "Remove all pokemon" command and restart VS Code.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-pokemon",
-    "version": "2.0.0",
+    "version": "3.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-pokemon",
-            "version": "2.0.0",
+            "version": "3.3.0",
             "license": "MIT",
             "dependencies": {
                 "@vscode/l10n": "^0.0.10"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-pokemon",
     "displayName": "vscode-pokemon",
     "description": "Pokémon for your VS Code",
-    "version": "3.2.2",
+    "version": "3.3.0",
     "engines": {
         "vscode": "^1.73.0"
     },
@@ -53,7 +53,8 @@
                     "type": "webview",
                     "id": "pokemonView",
                     "name": "VS Code Pokémon",
-                    "when": "vscode-pokemon.position == 'explorer'"
+                    "when": "vscode-pokemon.position == 'explorer'",
+                    "icon": "media/icon/dark-add.svg"
                 }
             ]
         },
@@ -195,6 +196,27 @@
                         ],
                         "default": "none",
                         "description": "Background theme assets for your pokemon"
+                    },
+                    "vscode-pokemon.defaultPokemon": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Pokemon type (e.g., 'pikachu', 'charizard', 'bulbasaur')"
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "description": "Custom name for the pokemon (optional)"
+                                }
+                            },
+                            "required": [
+                                "type"
+                            ]
+                        },
+                        "default": [],
+                        "description": "List of default pokemon to automatically spawn on startup. Each pokemon should have a 'type' (required), and optionally 'name'. Example: [{\"type\": \"pikachu\", \"name\": \"Sparky\"}, {\"type\": \"charizard\"}]"
                     }
                 }
             }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -338,19 +338,15 @@ export function activate(context: vscode.ExtensionContext) {
                 );
 
                 if (PokemonPanel.currentPanel) {
-                    // First, check if there are configured default pokemon
-                    const defaultPokemon = getConfiguredDefaultPokemon();
-                    let collection: PokemonSpecification[];
+                    // First, check if there are saved pokemon from previous session
+                    let collection = PokemonSpecification.collectionFromMemento(
+                        context,
+                        getConfiguredSize(),
+                    );
 
-                    if (defaultPokemon.length > 0) {
-                        // Use configured default pokemon
-                        collection = defaultPokemon;
-                    } else {
-                        // Fall back to memento (saved pokemon from previous session)
-                        collection = PokemonSpecification.collectionFromMemento(
-                            context,
-                            getConfiguredSize(),
-                        );
+                    if (collection.length === 0) {
+                        // Fall back to configured default pokemon if no saved session
+                        collection = getConfiguredDefaultPokemon();
                     }
 
                     collection.forEach((item) => {
@@ -1428,18 +1424,16 @@ class PokemonWebviewViewProvider extends PokemonWebviewContainer {
             this._disposables,
         );
 
-        const defaultPokemon = getConfiguredDefaultPokemon();
-        let collection: PokemonSpecification[];
+        // Load pokemon after the webview is ready
+        // First check if there are saved pokemon from previous session
+        let collection = PokemonSpecification.collectionFromMemento(
+            this._context,
+            getConfiguredSize(),
+        );
 
-        if (defaultPokemon.length > 0) {
-            // Use configured default pokemon
-            collection = defaultPokemon;
-        } else {
-            // Fall back to memento (saved pokemon from previous session)
-            collection = PokemonSpecification.collectionFromMemento(
-                this._context,
-                getConfiguredSize(),
-            );
+        if (collection.length === 0) {
+            // Fall back to configured default pokemon if no saved session
+            collection = getConfiguredDefaultPokemon();
         }
 
         // Small delay to ensure webview is fully loaded


### PR DESCRIPTION
Adds the option to set the default pokemon to be displayed through either the personal or the repo `settings.json`.

Also fixes the linting error regarding `originalSpriteSize`.

Disclaimer: I've used Copilot in coding this MR, but reviewed and changed all proposed changes where necessary.