### PR TITLE
Add option to periodically replace pokemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "vscode-pokemon" extension will be documented in this file.
 
+## [3.4.0]
+
+- feat: add option to periodically replace pokemon with random new ones
+
 ## [3.3.0]
 
 - feat: add default pokemon configurable through settings.json

--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ To configure default Pokémon, add the following to your `settings.json`:
     },
     {
       "type": "charizard",
-      "name": "Flame"
+      "name": "Flame",
+      "replacementInterval": 15
     },
     {
       "type": "articuno"
@@ -118,6 +119,7 @@ To configure default Pokémon, add the following to your `settings.json`:
 
 - **`type`** (required): The Pokémon species (e.g., `"pikachu"`, `"charizard"`, `"mewtwo"`)
 - **`name`** (optional): A custom name for your Pokémon. If not provided, a random name will be assigned
+- **`replacementInterval`** (optional): How long (in minutes) before this Pokémon is automatically replaced with a random one. Set to `0` or omit to never replace automatically
 
 **Note:** The extension automatically saves your current Pokémon between sessions. The `defaultPokemon` setting is only used when:
 - You start the extension for the first time
@@ -125,6 +127,35 @@ To configure default Pokémon, add the following to your `settings.json`:
 - You have removed all Pokémon (no saved session exists)
 
 To reset to your default Pokémon, use the "Remove all pokemon" command and restart VS Code.
+
+### Automatic Replacement
+
+You can configure Pokémon to automatically replace themselves with random ones after a specified time interval. This feature adds variety to your coding sessions!
+
+#### Global Default Replacement Interval
+Set a default replacement interval for all newly spawned Pokémon:
+
+```json
+{
+  "vscode-pokemon.defaultReplacementInterval": 30
+}
+```
+
+This setting controls the default interval (in minutes) for automatic replacement. Set to `0` to disable automatic replacement by default.
+
+#### Per-Pokémon Replacement Intervals
+When spawning individual Pokémon, you'll be prompted to set a custom replacement interval, or you can configure them in your default Pokémon list (see above).
+
+#### Replacement Notifications
+Control whether you see notifications when Pokémon are automatically replaced:
+
+```json
+{
+  "vscode-pokemon.showReplacementMessages": false
+}
+```
+
+Set to `false` to disable replacement notification messages. Default is `true` (notifications enabled).
 
 ## Upcoming features
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-pokemon",
-    "version": "3.3.0",
+    "version": "3.4.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-pokemon",
-            "version": "3.3.0",
+            "version": "3.4.0",
             "license": "MIT",
             "dependencies": {
                 "@vscode/l10n": "^0.0.10"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-pokemon",
     "displayName": "vscode-pokemon",
     "description": "Pokémon for your VS Code",
-    "version": "3.3.0",
+    "version": "3.4.0",
     "engines": {
         "vscode": "^1.73.0"
     },
@@ -197,6 +197,16 @@
                         "default": "none",
                         "description": "Background theme assets for your pokemon"
                     },
+                    "vscode-pokemon.defaultReplacementInterval": {
+                        "type": "number",
+                        "default": 0,
+                        "description": "Default replacement interval in minutes for newly spawned Pokemon. If > 0, Pokemon will be automatically replaced with a random one after this duration. 0 = never replace."
+                    },
+                    "vscode-pokemon.showReplacementMessages": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Show notification messages when Pokemon are automatically replaced. Set to false to disable replacement notifications."
+                    },
                     "vscode-pokemon.defaultPokemon": {
                         "type": "array",
                         "items": {
@@ -209,6 +219,10 @@
                                 "name": {
                                     "type": "string",
                                     "description": "Custom name for the pokemon (optional)"
+                                },
+                                "replacementInterval": {
+                                    "type": "number",
+                                    "description": "How long (in minutes) before this pokemon is automatically replaced with a random one. 0 = never replace (optional)"
                                 }
                             },
                             "required": [
@@ -216,7 +230,7 @@
                             ]
                         },
                         "default": [],
-                        "description": "List of default pokemon to automatically spawn on startup. Each pokemon should have a 'type' (required), and optionally 'name'. Example: [{\"type\": \"pikachu\", \"name\": \"Sparky\"}, {\"type\": \"charizard\"}]"
+                        "description": "List of default pokemon to automatically spawn on startup. Each pokemon should have a 'type' (required), and optionally 'name' and 'replacementInterval'. Example: [{\"type\": \"pikachu\", \"name\": \"Sparky\", \"replacementInterval\": 10}, {\"type\": \"charizard\"}]"
                     }
                 }
             }

--- a/src/panel/pokemon-collection.ts
+++ b/src/panel/pokemon-collection.ts
@@ -11,6 +11,8 @@ export class PokemonElement {
     type: PokemonType;
     generation: string;
     originalSpriteSize: number;
+    ageInMinutes: number = 0;
+    replacementInterval: number = 0;
     remove() {
         this.el.remove();
         this.collision.remove();
@@ -27,6 +29,7 @@ export class PokemonElement {
         type: PokemonType,
         generation: string,
         originalSpriteSize: number,
+        replacementInterval: number = 0,
     ) {
         this.el = el;
         this.collision = collision;
@@ -36,6 +39,7 @@ export class PokemonElement {
         this.type = type;
         this.generation = generation;
         this.originalSpriteSize = originalSpriteSize;
+        this.replacementInterval = replacementInterval;
     }
 }
 
@@ -168,7 +172,7 @@ export function createPokemon(
             name,
             PokemonSpeed.normal,
             generation,
-            originalSpriteSize 
+            originalSpriteSize
         );
     } catch (error) {
         throw new InvalidPokemonException(`Invalid Pokemon type: ${pokemonType}`);

--- a/src/panel/states.ts
+++ b/src/panel/states.ts
@@ -50,6 +50,8 @@ export class PokemonElementState {
     elBottom: string | undefined;
     pokemonName: string | undefined;
     pokemonFriend: string | undefined;
+    pokemonAgeInMinutes: number | undefined;
+    pokemonReplacementInterval: number | undefined;
 }
 
 export class PokemonPanelState {


### PR DESCRIPTION
This MR resolves https://github.com/jakobhoeg/vscode-pokemon/issues/42 and enables automatic replacement of pokemon if configured accordingly upon spawn.

Also fixes a linter error regarding `padStart`.

If you would prefer a different behavior for this, let me know and I'll try to implement it.

Disclaimer: Github Copilot was involved in the creation of this MR, everything has been checked and modified by me.

---

On a personal note, can I just say that I really like what this extension does and think it is really cool. Thank you for creating and maintaining it :)