### PR TITLE
fix: Corphish in pokemon-data.ts

### DIFF
--- a/src/common/pokemon-data.ts
+++ b/src/common/pokemon-data.ts
@@ -2380,11 +2380,11 @@ export const POKEMON_DATA: { [key: string]: PokemonConfig } = {
     cry: 'Whiscash!',
     possibleColors: [PokemonColor.default],
   },
-  corpish: {
+  corphish: {
     id: 341,
-    name: 'Corpish',
+    name: 'Corphish',
     generation: PokemonGeneration.Gen3,
-    cry: 'Corpish!',
+    cry: 'Corphish!',
     possibleColors: [PokemonColor.default],
   },
   crawdaunt: {


### PR DESCRIPTION
Corphish was missing, noticed that there was also an issue (#64) already on that. So I thought I would fix it, so we can all enjoy its company 😊

closes #64 

## What this PR does
I saw it was a simple typo in the `pokemon-data.ts` file and therefore just added the **h**. 

