### PR TITLE
Change speed depending on size

### DIFF
--- a/src/panel/base-pokemon-type.ts
+++ b/src/panel/base-pokemon-type.ts
@@ -45,7 +45,7 @@ export abstract class BasePokemonType implements IPokemonType {
     _floor: number;
     _friend: IPokemonType | undefined;
     private _name: string;
-    private _speed: number;
+    private _baseSpeed: number;
     private _size: PokemonSize;
     private _generation: string;
     private _originalSpriteSize: number;
@@ -78,7 +78,7 @@ export abstract class BasePokemonType implements IPokemonType {
 
         this._name = name;
         this._size = size;
-        this._speed = this.randomizeSpeed(speed);
+        this._baseSpeed = this.randomizeSpeed(speed);
         this._generation = generation;
 
         // Increment the static count of the Pokemon class that the constructor belongs to
@@ -168,7 +168,19 @@ export abstract class BasePokemonType implements IPokemonType {
     }
 
     get speed(): number {
-        return this._speed;
+        const base = this._baseSpeed ?? 0;
+        switch (this._size) {
+            case PokemonSize.nano:
+                return base * 0.5; // much slower for nano
+            case PokemonSize.small:
+                return base * 0.75; // slower for small
+            case PokemonSize.medium:
+                return base * 1.0; // baseline
+            case PokemonSize.large:
+                return base * 1.25; // slightly faster for large
+            default:
+                return base;
+        }
     }
 
     randomizeSpeed(speed: number): number {
@@ -179,7 +191,7 @@ export abstract class BasePokemonType implements IPokemonType {
     }
 
     get isMoving(): boolean {
-        return this._speed !== PokemonSpeed.still;
+        return this._baseSpeed !== PokemonSpeed.still;
     }
 
     recoverFriend(friend: IPokemonType) {


### PR DESCRIPTION
This pull request updates the handling of Pokémon speed in the `BasePokemonType` class to make speed calculations dynamic based on Pokémon size. The changes replace the previous static speed property with a base speed, and the actual speed is now computed on the fly depending on the Pokémon's size.

**Refactor and dynamic speed calculation:**

* Renamed the private field from `_speed` to `_baseSpeed` and updated its assignment in the constructor to reflect the new naming. [[1]](diffhunk://#diff-d9107138e3ab56b084ca48e266a909cbab115f2a62e43403d5f9834ab3be0e55L48-R48) [[2]](diffhunk://#diff-d9107138e3ab56b084ca48e266a909cbab115f2a62e43403d5f9834ab3be0e55L81-R81)
* Updated the `speed` getter to dynamically calculate speed based on `_baseSpeed` and the Pokémon's `size`, applying different multipliers for each size category.
* Updated the `isMoving` getter to check against `_baseSpeed` instead of the old `_speed` property. 
* #83 