### PR TITLE
feat: add manage presets functionality and related commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "onCommand:vscode-pokemon.roll-call",
         "onCommand:vscode-pokemon.export-pokemon-list",
         "onCommand:vscode-pokemon.import-pokemon-list",
+        "onCommand:vscode-pokemon.manage-presets",
         "onCommand:vscode-pokemon.configure-keybindings",
         "onWebviewPanel:pokemonCoding",
         "onView:explorer",
@@ -137,6 +138,12 @@
             {
                 "command": "vscode-pokemon.configure-keybindings",
                 "title": "Configure keybindings",
+                "category": "Pokemon Coding"
+            }
+            ,
+            {
+                "command": "vscode-pokemon.manage-presets",
+                "title": "Manage Pokemon Presets",
                 "category": "Pokemon Coding"
             }
         ],

--- a/src/constants/vscode-keys.ts
+++ b/src/constants/vscode-keys.ts
@@ -1,0 +1,11 @@
+export const VSCODE_PRESETS_KEY = 'vscode-pokemon.presets';
+export const VSCODE_START_KEY = 'vscode-pokemon.start';
+export const VSCODE_SPAWN_POKEMON_KEY = 'vscode-pokemon.spawn-pokemon';
+export const VSCODE_SPAWN_RANDOM_POKEMON_KEY = 'vscode-pokemon.spawn-random-pokemon';
+export const VSCODE_DELETE_POKEMON_KEY = 'vscode-pokemon.delete-pokemon';
+export const VSCODE_REMOVE_ALL_POKEMON_KEY = 'vscode-pokemon.remove-all-pokemon';
+export const VSCODE_ROLL_CALL_KEY = 'vscode-pokemon.roll-call';
+export const VSCODE_EXPORT_POKEMON_LIST_KEY = 'vscode-pokemon.export-pokemon-list';
+export const VSCODE_IMPORT_POKEMON_LIST_KEY = 'vscode-pokemon.import-pokemon-list';
+export const VSCODE_MANAGE_PRESETS_KEY = 'vscode-pokemon.manage-presets';
+export const VSCODE_CONFIGURE_KEYBINDINGS_KEY = 'vscode-pokemon.configure-keybindings';


### PR DESCRIPTION
I made a way to save the current Pokémon on screen in a present that can then later be called upon to spawn in those Pokémon.

I also made some one the VSCode keys into a constant file that is easier to change and maintain.

This Pull Request should also resolve #70