### PR TITLE
fix: update Pokemon z-index and add theme selection commands

### DIFF
--- a/media/pokemon.css
+++ b/media/pokemon.css
@@ -126,7 +126,7 @@ img.pokemon {
 	left: 0px;
 	right: 0px;
 	bottom: 0px;
-	z-index: 2;
+	z-index: 10;
 }
 
 .collision {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "onCommand:vscode-pokemon.roll-call",
         "onCommand:vscode-pokemon.export-pokemon-list",
         "onCommand:vscode-pokemon.import-pokemon-list",
+        "onCommand:vscode-pokemon.set-random-theme",
         "onCommand:vscode-pokemon.configure-keybindings",
         "onCommand:vscode-pokemon.change-pokemon-language",
         "onWebviewPanel:pokemonCoding",
@@ -133,6 +134,11 @@
             {
                 "command": "vscode-pokemon.roll-call",
                 "title": "Roll-call",
+                "category": "Pokemon Coding"
+            },
+            {
+                "command": "vscode-pokemon.set-random-theme",
+                "title": "Set random theme",
                 "category": "Pokemon Coding"
             },
             {

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -518,6 +518,29 @@ export function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     vscode.commands.registerCommand(
+      'vscode-pokemon.set-random-theme',
+      async () => {
+        // Get available themes (excluding 'none')
+        const availableThemes = [Theme.forest, Theme.castle, Theme.beach];
+        // Select random theme
+        const randomTheme =
+          availableThemes[Math.floor(Math.random() * availableThemes.length)];
+
+        // Update the configuration
+        await vscode.workspace
+          .getConfiguration('vscode-pokemon')
+          .update('theme', randomTheme, vscode.ConfigurationTarget.Global);
+
+        // Show notification
+        await vscode.window.showInformationMessage(
+          vscode.l10n.t('Theme changed to: {0}', randomTheme),
+        );
+      },
+    ),
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
       'vscode-pokemon.configure-keybindings',
       async () => {
         const items: Array<vscode.QuickPickItem & { commandId: string }> = [


### PR DESCRIPTION
## Summary
Fixes Pokemon appearing behind trees and bushes by adjusting z-index values. Also adds convenient commands for theme management.

## Changes
- **Fix z-index issue**: Increased Pokemon z-index from 2 to 10 to display them in front of foreground elements (trees, bushes) which have z-index 5
- **Add "Set random theme" command**: Randomly selects between forest, castle, and beach themes

## Fixes
Closes #19

## Test plan
1. Enable a theme (forest/castle/beach) in settings
2. Verify Pokemon now appear in front of trees and bushes
3. Test new commands:
   - "Pokemon Coding: Set random theme" - should randomly pick a theme
   
## Results
<img width="512" height="512" alt="CleanShot 2026-02-13 at 20 53 36@2x" src="https://github.com/user-attachments/assets/fff4e809-572b-46c4-b171-b37dc82b8f41" />
