### PR TITLE
feat: add shiny configuration option to default Pokemon settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ To configure default Pokémon, add the following to your `settings.json`:
 
 - **`type`** (required): The Pokémon species (e.g., `"pikachu"`, `"charizard"`, `"mewtwo"`)
 - **`name`** (optional): A custom name for your Pokémon. If not provided, a random name will be assigned
+- **`shiny`** (optional): Determines if the Pokémon is shiny, if not set will use `vscode-pokemon.shinyOdds` setting.
 
 **Note:** The extension automatically saves your current Pokémon between sessions. The `defaultPokemon` setting is only used when:
 - You start the extension for the first time

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -110,6 +110,7 @@ function maybeMakeShiny(possibleColors: PokemonColor[]): PokemonColor {
 interface IDefaultPokemonConfig {
   type: PokemonType;
   name?: string;
+  shiny?: boolean;
 }
 
 function getConfiguredDefaultPokemon(): PokemonSpecification[] {
@@ -124,9 +125,18 @@ function getConfiguredDefaultPokemon(): PokemonSpecification[] {
     // Validate that the pokemon type exists
     if (POKEMON_DATA[config.type]) {
       const name = config.name || randomName();
-      result.push(
-        new PokemonSpecification(DEFAULT_COLOR, config.type, size, name),
-      );
+
+      // If shiny is not specified, default to color to maybeShiny with the pokemon's available colors. If shiny is true, force shiny color. If shiny is false, force default color.
+      let color: PokemonColor;
+      if (config.shiny === undefined) {
+        color = maybeMakeShiny(availableColors(config.type));
+      } else if (config.shiny) {
+        color = PokemonColor.shiny;
+      } else {
+        color = DEFAULT_COLOR;
+      }
+
+      result.push(new PokemonSpecification(color, config.type, size, name));
     } else {
       console.warn(
         `Invalid pokemon type in defaultPokemon config: ${config.type}`,


### PR DESCRIPTION
This pull request updates how default Pokémon are configured, allowing for explicit control over whether a Pokémon is shiny. The main improvement is the addition of a `shiny` property to the configuration interface and updated logic to select the Pokémon's color based on this property.

Configuration enhancements:

* Added an optional `shiny` boolean property to the `IDefaultPokemonConfig` interface, allowing users to specify if a Pokémon should be shiny.

Logic updates:

* Modified the `getConfiguredDefaultPokemon` function to use the new `shiny` property: if `shiny` is true, the shiny color is used; if false, the default color is used; if not specified, the color is determined randomly as before.

This will also resolve #108