### PR TITLE
fix: prevent spawning empty Pokémon collection on session start

### DIFF
--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -167,6 +167,12 @@ function getDefaultPokemonForFreshSession(
   return getConfiguredDefaultPokemon();
 }
 
+export function shouldSpawnInitialCollection(
+  collection: PokemonSpecification[],
+): boolean {
+  return collection.length > 0;
+}
+
 async function spawnAndPersistCollection(
   context: vscode.ExtensionContext,
   panel: IPokemonPanel,
@@ -1075,11 +1081,13 @@ export function activate(context: vscode.ExtensionContext) {
 
         if (PokemonPanel.currentPanel) {
           const collection = getDefaultPokemonForFreshSession(context);
-          await spawnAndPersistCollection(
-            context,
-            PokemonPanel.currentPanel,
-            collection,
-          );
+          if (shouldSpawnInitialCollection(collection)) {
+            await spawnAndPersistCollection(
+              context,
+              PokemonPanel.currentPanel,
+              collection,
+            );
+          }
         }
       },
     });
@@ -1607,7 +1615,9 @@ class PokemonWebviewViewProvider extends PokemonWebviewContainer {
     );
 
     const collection = getDefaultPokemonForFreshSession(this._context);
-    await spawnAndPersistCollection(this._context, this, collection);
+    if (shouldSpawnInitialCollection(collection)) {
+      await spawnAndPersistCollection(this._context, this, collection);
+    }
   }
 
   update() {


### PR DESCRIPTION
This pull request improves the logic for spawning the initial Pokémon collection in the extension by ensuring that collections are only spawned when there are Pokémon to add. The main change is the introduction of a helper function to check if the collection is non-empty before proceeding. This prevents unnecessary function calls and potential errors when the collection is empty.

Logic improvements for spawning Pokémon collections:

* Added a new `shouldSpawnInitialCollection` function to check if the Pokémon collection is non-empty before attempting to spawn and persist it (`src/extension/extension.ts`).
* Updated both the command handler in `activate` and the `PokemonWebviewViewProvider` class to use `shouldSpawnInitialCollection` before calling `spawnAndPersistCollection` (`src/extension/extension.ts`). [[1]](diffhunk://#diff-2f46814827e2ed95cdb578341aff004f3e6e2da7f43acd6d8b1686b4db02733cR1084-R1091) [[2]](diffhunk://#diff-2f46814827e2ed95cdb578341aff004f3e6e2da7f43acd6d8b1686b4db02733cR1618-R1621)

This should resolve #110 