### PR TITLE
fix: resolve delay when removing more than one pokemon quickly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "vscode-pokemon" extension will be documented in this file.
 
+## [4.3.5]
+
+- fix: resolve delay when removing more than one pokemon quickly
+
 ## [4.3.4]
 
 - feat: add shiny configuration option to default Pokemon settings

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-pokemon",
     "displayName": "vscode-pokemon",
     "description": "Pokémon for your VS Code",
-    "version": "4.3.4",
+    "version": "4.3.5",
     "engines": {
         "vscode": "^1.73.0"
     },

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -317,67 +317,30 @@ interface IPokemonInfo {
   color: PokemonColor;
 }
 
-async function handleRemovePokemonMessage(
-  this: vscode.ExtensionContext,
-  message: WebviewMessage,
-) {
-  var pokemonList: IPokemonInfo[] = [];
-  switch (message.command) {
-    case 'list-pokemon':
-      message.text.split('\n').forEach((pokemon) => {
-        if (!pokemon) {
+function waitForPokemonList(webview: vscode.Webview): Promise<IPokemonInfo[]> {
+  return new Promise((resolve) => {
+    const disposable = webview.onDidReceiveMessage(
+      (message: WebviewMessage) => {
+        if (message.command !== 'list-pokemon') {
           return;
         }
-        var parts = pokemon.split(',');
-        pokemonList.push({
-          type: parts[0] as PokemonType,
-          name: parts[1],
-          color: parts[2] as PokemonColor,
+        disposable.dispose();
+        const pokemonList: IPokemonInfo[] = [];
+        message.text.split('\n').forEach((pokemon) => {
+          if (!pokemon) {
+            return;
+          }
+          var parts = pokemon.split(',');
+          pokemonList.push({
+            type: parts[0] as PokemonType,
+            name: parts[1],
+            color: parts[2] as PokemonColor,
+          });
         });
-      });
-      break;
-    default:
-      return;
-  }
-  if (!pokemonList) {
-    return;
-  }
-  if (!pokemonList.length) {
-    await vscode.window.showErrorMessage(
-      vscode.l10n.t('There are no pokemon to remove.'),
-    );
-    return;
-  }
-  await vscode.window
-    .showQuickPick<PokemonQuickPickItem>(
-      pokemonList.map((val) => {
-        return new PokemonQuickPickItem(val.name, val.type, val.color);
-      }),
-      {
-        placeHolder: vscode.l10n.t('Select the pokemon to remove.'),
+        resolve(pokemonList);
       },
-    )
-    .then(async (pokemon: PokemonQuickPickItem | undefined) => {
-      if (pokemon) {
-        const panel = getPokemonPanel();
-        if (panel !== undefined) {
-          panel.deletePokemon(pokemon.name);
-          const collection = pokemonList
-            .filter((item) => {
-              return item.name !== pokemon.name;
-            })
-            .map<PokemonSpecification>((item) => {
-              return new PokemonSpecification(
-                item.color,
-                item.type,
-                PokemonSize.medium,
-                item.name,
-              );
-            });
-          await storeCollectionAsMemento(this, collection);
-        }
-      }
-    });
+    );
+  });
 }
 
 function getPokemonPanel(): IPokemonPanel | undefined {
@@ -488,14 +451,47 @@ export function activate(context: vscode.ExtensionContext) {
       'vscode-pokemon.delete-pokemon',
       async () => {
         const panel = getPokemonPanel();
-        if (panel !== undefined) {
-          panel.listPokemon();
-          getWebview()?.onDidReceiveMessage(
-            handleRemovePokemonMessage,
-            context,
-          );
-        } else {
+        if (panel === undefined) {
           await createPokemonPlayground(context);
+          return;
+        }
+        const webview = getWebview();
+        if (!webview) {
+          return;
+        }
+        const listPromise = waitForPokemonList(webview);
+        panel.listPokemon();
+        const pokemonList = await listPromise;
+
+        if (!pokemonList.length) {
+          await vscode.window.showErrorMessage(
+            vscode.l10n.t('There are no pokemon to remove.'),
+          );
+          return;
+        }
+        const pokemon = await vscode.window.showQuickPick<PokemonQuickPickItem>(
+          pokemonList.map((val) => {
+            return new PokemonQuickPickItem(val.name, val.type, val.color);
+          }),
+          {
+            placeHolder: vscode.l10n.t('Select the pokemon to remove.'),
+          },
+        );
+        if (pokemon) {
+          panel.deletePokemon(pokemon.name);
+          const collection = pokemonList
+            .filter((item) => {
+              return item.name !== pokemon.name;
+            })
+            .map<PokemonSpecification>((item) => {
+              return new PokemonSpecification(
+                item.color,
+                item.type,
+                PokemonSize.medium,
+                item.name,
+              );
+            });
+          await storeCollectionAsMemento(context, collection);
         }
       },
     ),

--- a/src/panel/main.ts
+++ b/src/panel/main.ts
@@ -290,6 +290,18 @@ function removePokemonFromPanel(
   console.log('Removing pokemon ', message.name);
   console.log('pokemon:', pokemon);
 
+  // Remove from collection immediately so rapid deletes of Pokemon don't interfere with each other
+  allPokemon.removeFromCollection(message.name);
+  pokemon.collision.remove();
+  pokemon.speech.remove();
+  pokemonCounter = normalizePokemonCounter(pokemonCounter - 1);
+  saveState(stateApi);
+
+  stateApi?.postMessage({
+    command: 'info',
+    text: '👋 Removed pokemon ' + message.name,
+  });
+
   // pokemon fade out
   pokemonSpriteElement.classList.add('fade-out');
 
@@ -324,18 +336,7 @@ function removePokemonFromPanel(
       if (e.animationName !== 'pokeball-close') {
         return;
       }
-
       pokeballEl.remove();
-
-      // 🔥 only now we change the state
-      allPokemon.remove(message.name);
-      pokemonCounter = normalizePokemonCounter(pokemonCounter - 1);
-      saveState(stateApi);
-
-      stateApi?.postMessage({
-        command: 'info',
-        text: '👋 Removed pokemon ' + message.name,
-      });
     },
     { once: true },
   );

--- a/src/panel/pokemon-collection.ts
+++ b/src/panel/pokemon-collection.ts
@@ -51,6 +51,7 @@ export interface IPokemonCollection {
   seekNewFriends(): string[];
   locate(name: string): PokemonElement | undefined;
   remove(name: string): void;
+  removeFromCollection(name: string): void;
 }
 
 export class PokemonCollection implements IPokemonCollection {
@@ -89,6 +90,16 @@ export class PokemonCollection implements IPokemonCollection {
       return;
     }
     this._pokemonCollection[idx].remove();
+    this._pokemonCollection.splice(idx, 1);
+  }
+
+  removeFromCollection(name: string): void {
+    const idx = this._pokemonCollection.findIndex(
+      (pokemon) => pokemon.pokemon.name === name,
+    );
+    if (idx === -1) {
+      return;
+    }
     this._pokemonCollection.splice(idx, 1);
   }
 


### PR DESCRIPTION
- Fixed stacking `onDidReceiveMessage` listeners in the delete command that were never disposed
- Replaced with a promise-based `waitForPokemonList()` that auto-disposes after receiving the `list-pokemon` response 
- Moved pokemon collection removal to happen **immediately** in `removePokemonFromPanel` instead of waiting for the 0.6s pokeball-close animation, preventing stale state from overwriting subsequent deletes