### PR TITLE
feat: add random pokémon spawn support to default Pokemon settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,19 +111,33 @@ To configure default Pokémon, add the following to your `settings.json`:
     },
     {
       "type": "articuno"
+    },
+    {
+      "type": "mewtwo",
+      "shiny": true
+    },
+    {
+      "type": "random"
+    },
+    {
+      "type": "random",
+      "pool": ["pikachu", "eevee", "gengar", "snorlax"]
     }
   ]
 }
 ```
 
-- **`type`** (required): The Pokémon species (e.g., `"pikachu"`, `"charizard"`, `"mewtwo"`)
+- **`type`** (required): The Pokémon species (e.g., `"pikachu"`, `"charizard"`, `"mewtwo"`), or `"random"` to spawn a random species
 - **`name`** (optional): A custom name for your Pokémon. If not provided, a random name will be assigned
 - **`shiny`** (optional): Determines if the Pokémon is shiny, if not set will use `vscode-pokemon.shinyOdds` setting.
+- **`pool`** (optional): Only used when `type` is `"random"`. Restricts the random selection to this list of species. Invalid entries are dropped with a warning; if none are valid, selection falls back to any Pokémon.
 
 **Note:** The extension automatically saves your current Pokémon between sessions. The `defaultPokemon` setting is only used when:
 - You start the extension for the first time
 - You open a new windows/repository
 - You have removed all Pokémon (no saved session exists)
+
+A `"random"` entry is resolved to a specific species the first time it's applied, then saved like any other Pokémon — reopening the window won't re-roll it, only removing all Pokémon will.
 
 To reset to your default Pokémon, use the "Remove all pokemon" command and restart VS Code.
 

--- a/package.json
+++ b/package.json
@@ -210,11 +210,22 @@
                             "properties": {
                                 "type": {
                                     "type": "string",
-                                    "description": "Pokemon type (e.g., 'pikachu', 'charizard', 'bulbasaur')"
+                                    "description": "Pokemon type (e.g., 'pikachu', 'charizard', 'bulbasaur'), or 'random' to spawn a random species"
                                 },
                                 "name": {
                                     "type": "string",
                                     "description": "Custom name for the pokemon (optional)"
+                                },
+                                "shiny": {
+                                    "type": "boolean",
+                                    "description": "Force this pokemon to be shiny (true) or non-shiny (false). If omitted, uses vscode-pokemon.shinyOdds (optional)"
+                                },
+                                "pool": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "description": "When type is 'random', restrict the random selection to this list of pokemon species (e.g. ['pikachu', 'eevee', 'gengar']). Ignored for non-random types (optional)"
                                 }
                             },
                             "required": [
@@ -222,7 +233,7 @@
                             ]
                         },
                         "default": [],
-                        "description": "List of default pokemon to automatically spawn on startup. Each pokemon should have a 'type' (required), and optionally 'name'. Example: [{\"type\": \"pikachu\", \"name\": \"Sparky\"}, {\"type\": \"charizard\"}]"
+                        "description": "List of default pokemon to automatically spawn on startup. Each pokemon should have a 'type' (required, or 'random' to spawn a random species), and optionally 'name', 'shiny', and 'pool' (for random selection). Example: [{\"type\": \"pikachu\", \"name\": \"Sparky\"}, {\"type\": \"random\", \"pool\": [\"eevee\", \"gengar\", \"snorlax\"]}]"
                     },
                     "vscode-pokemon.shinyOdds": {
                         "type": "number",

--- a/src/common/pokemon-data.ts
+++ b/src/common/pokemon-data.ts
@@ -4032,6 +4032,18 @@ export function getDefaultPokemon(): PokemonType {
   return 'bulbasaur';
 }
 
+/**
+ * Returns a random Pokemon config from a given pool.
+ * @param types The keys to choose from.
+ * @returns A random Pokemon config from the given pool.
+ */
+export function getRandomPokemonConfigFrom(
+  types: PokemonType[],
+): [PokemonType, PokemonConfig] {
+  const randomType = types[Math.floor(Math.random() * types.length)];
+  return [randomType, POKEMON_DATA[randomType]];
+}
+
 export function getRandomPokemonConfig(): [PokemonType, PokemonConfig] {
   const keys = Object.keys(POKEMON_DATA);
   const randomKey = keys[Math.floor(Math.random() * keys.length)];

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -3,9 +3,11 @@ import { ColorThemeKind } from 'vscode';
 import * as localize from '../common/localize';
 import { randomName } from '../common/names';
 import {
+  getAllPokemon,
   getDefaultPokemon as getDefaultPokemonType,
   getPokemonByGeneration,
   getRandomPokemonConfig,
+  getRandomPokemonConfigFrom,
   POKEMON_DATA,
 } from '../common/pokemon-data';
 import {
@@ -111,6 +113,49 @@ interface IDefaultPokemonConfig {
   type: PokemonType;
   name?: string;
   shiny?: boolean;
+  pool?: PokemonType[];
+}
+
+/**
+ * Resolves a 'random' defaultPokemon entry to a concrete type, optionally
+ * constrained to `pool`. Falls back to the full types list if `pool` is
+ * empty or contains no valid entries (invalid entries are warned about, not
+ * treated as fatal).
+ */
+function resolveRandomPokemonType(pool?: PokemonType[]): PokemonType {
+  const allPokemon = getAllPokemon();
+
+  if (!pool || pool.length === 0) {
+    const [randomPokemonType] = getRandomPokemonConfigFrom(allPokemon);
+    return randomPokemonType;
+  }
+
+  // Normalize pool entries for case-insensitive matching
+  const normalizedPool = pool.map((entry) => entry.toLowerCase().trim());
+
+  const invalidPoolEntries = normalizedPool.filter(
+    (entry) => !allPokemon.includes(entry as PokemonType),
+  );
+  if (invalidPoolEntries.length > 0) {
+    console.warn(
+      `Invalid pokemon type(s) in defaultPokemon pool: ${invalidPoolEntries.join(', ')}`,
+    );
+  }
+
+  const validPoolEntries = normalizedPool.filter((entry) =>
+    allPokemon.includes(entry as PokemonType),
+  ) as PokemonType[];
+  if (validPoolEntries.length === 0) {
+    console.warn(
+      `No valid pokemon in defaultPokemon pool, falling back to random selection from all pokemon`,
+    );
+  }
+
+  // Fall back to the full pokemon list if the pool was empty or fully invalid
+  const candidateKeys =
+    validPoolEntries.length > 0 ? validPoolEntries : allPokemon;
+  const [randomPokemonType] = getRandomPokemonConfigFrom(candidateKeys);
+  return randomPokemonType;
 }
 
 function getConfiguredDefaultPokemon(): PokemonSpecification[] {
@@ -123,25 +168,35 @@ function getConfiguredDefaultPokemon(): PokemonSpecification[] {
 
   for (const config of defaultConfig) {
     // Validate that the pokemon type exists
-    if (POKEMON_DATA[config.type]) {
-      const name = config.name || randomName();
-
-      // If shiny is not specified, default to color to maybeShiny with the pokemon's available colors. If shiny is true, force shiny color. If shiny is false, force default color.
-      let color: PokemonColor;
-      if (config.shiny === undefined) {
-        color = maybeMakeShiny(availableColors(config.type));
-      } else if (config.shiny) {
-        color = PokemonColor.shiny;
-      } else {
-        color = DEFAULT_COLOR;
-      }
-
-      result.push(new PokemonSpecification(color, config.type, size, name));
-    } else {
+    if (config.type !== 'random' && !POKEMON_DATA[config.type]) {
       console.warn(
         `Invalid pokemon type in defaultPokemon config: ${config.type}`,
       );
+      continue;
     }
+
+    const resolvedType: PokemonType =
+      config.type === 'random'
+        ? resolveRandomPokemonType(config.pool)
+        : config.type;
+
+    const name = config.name || randomName();
+
+    /**
+     * If shiny is not specified, default color to maybeMakeShiny with the
+     * pokemon's available colors. If shiny is true, force shiny color. If
+     * shiny is false, force default color.
+     */
+    let color: PokemonColor;
+    if (config.shiny === undefined) {
+      color = maybeMakeShiny(availableColors(resolvedType));
+    } else if (config.shiny) {
+      color = PokemonColor.shiny;
+    } else {
+      color = DEFAULT_COLOR;
+    }
+
+    result.push(new PokemonSpecification(color, resolvedType, size, name));
   }
 
   return result;


### PR DESCRIPTION
## Summary
- Adds `'random'` as a valid `type` value for `vscode-pokemon.defaultPokemon` entries, so a random species spawns on session start instead of a fixed one.
- Adds an optional `pool` array to constrain the random selection to a user-chosen list of species (e.g. `['pikachu', 'eevee', 'gengar', 'snorlax']`). Invalid pool entries are matched case-insensitively and dropped with a `console.warn`; if the pool ends up empty or fully invalid, selection falls back to the full species list (also warned).
- Fixes a pre-existing gap in the `defaultPokemon` JSON schema (`package.json`) where `shiny` was supported in code but never declared in the schema, so VS Code's settings IntelliSense didn't surface it. Both `shiny` and the new `pool` property are now documented in the schema.
- Updates `README.md` with new examples (`random`, `random` + `pool`, `shiny`) and documents the resolve-once-then-persist behavior of a `random` entry.

Closes #116

## Test plan
Verified manually in the Extension Development Host with:

```json
{
  "vscode-pokemon.defaultPokemon": [
    { "type": "random" },
    { "type": "random", "shiny": true },
    { "type": "random", "pool": ["pikachu", "eevee", "gengar", "snorlax"] },
    { "type": "random", "pool": ["not_a_real_pokemon", "articuno"] },
    { "type": "random", "pool": ["totally_bogus"] },
    { "type": "random", "pool": ["blastoise", "venusaur"], "shiny": true },
    { "type": "charizard", "name": "Flame" }
  ]
}
```

- [x] `{ "type": "random" }` spawns a random species on a fresh session
- [x] `{ "type": "random", "shiny": true }` spawns a random species, forced shiny
- [x] `{ "type": "random", "pool": [...] }` with a fully valid pool always resolves within the pool (verified across multiple "Remove all Pokemon" + reload cycles)
- [x] Partially invalid pool drops the invalid entries only, logs a `console.warn`, and still picks from the valid remainder
- [x] Fully invalid/empty pool falls back to unconstrained random selection, logs a `console.warn`
- [x] Existing concrete-type entries (e.g. `'charizard'`) are unaffected — no regression
- [x] A resolved random species persists across window reloads (not re-rolled) as long as the saved session isn't cleared, matching existing `defaultPokemon` persistence behavior
- [x] `pool` and `shiny` now appear in VS Code settings IntelliSense/hover for `defaultPokemon` entries after the schema update
- [x] `npm run lint` and `tsc` type-check clean on all changed files
- [x] `npm run format` (Prettier) applied to changed source files